### PR TITLE
Fix: filtering

### DIFF
--- a/app.js
+++ b/app.js
@@ -280,8 +280,10 @@ function initServer (args) {
     app.post(_routes.editview, r.auth.restrict, r.editview.post, r.render.admin);
 
     // listview
+    // STEFAN: what is '_routes.listview'? Where is this filter object being constructed?
+    // console.log('>>>>>>>>>> _routes.listview: ', _routes.listview)
     app.get(_routes.listview, r.auth.restrict, r.listview.get, r.render.admin);
-    app.post(_routes.listview, r.auth.restrict, r.listview.post, r.render.admin);
+    app.post(_routes.listview, r.auth.restrict, r.filter.hotfix, r.listview.post, r.render.admin);
 
     // mainview
     app.get(_routes.mainview, r.auth.restrict, r.mainview.get, r.render.admin);

--- a/lib/app/settings.js
+++ b/lib/app/settings.js
@@ -27,6 +27,9 @@ exports.refresh = function (settings, info) {
       if (exists(settings[table].columns, name)) continue;
 
       settings[table].columns.push(createColumn(name, columns[name]));
+
+      // STEFAN: add all column names as filterable
+      settings[table].listview.filter.push(name);
     }
   }
   return settings;
@@ -56,6 +59,32 @@ function exists (columns, name) {
  */
 
 function createTable (name, pk, view) {
+  // STEFAN: don't display association tables. Predicate on multiple primary keys.
+  if (Array.isArray(pk)) {
+    return {
+      slug: slugify(name),
+      table: {
+        name: name,
+        pk: pk,
+        verbose: name,
+        view: view
+      },
+      columns: [],
+      mainview: {
+        show: false
+      },
+      listview: {
+        order: {},
+        // STEFAN: default 200 entities per page.
+        page: 200,
+      // STEFAN ability to filter by all fields by default
+      filter: []
+      },
+      editview: {
+        readonly: false
+      }
+    };
+  }
   return {
     slug: slugify(name),
     table: {
@@ -70,8 +99,10 @@ function createTable (name, pk, view) {
     },
     listview: {
       order: {},
-      // Stefan: default 200 entities per page.
-      page: 200
+      // STEFAN: default 200 entities per page.
+      page: 200,
+      // STEFAN ability to filter by all fields by default
+      filter: []
     },
     editview: {
       readonly: false
@@ -89,7 +120,7 @@ function createTable (name, pk, view) {
  */
 
 function createColumn (name, info) {
-  // Stefan: Don't edit timestamps or IDs.
+  // STEFAN: Don't edit timestamps or IDs.
   if (name === 'id' || name === 'createdAt' || name === 'updatedAt') {
     return {
       name: name,

--- a/lib/listview/filter.js
+++ b/lib/listview/filter.js
@@ -3,11 +3,14 @@ var dcopy = require('deep-copy');
 
 
 exports.prepareSession = function (req, args) {
-    if (!req.session.filter) req.session.filter = {};
+    if (!req.session.filter) {
+      req.session.filter = {};
+    }
     var filter = req.session.filter;
-
+    
     if ((req.method == 'GET' && !filter.hasOwnProperty(args.name))
-    || (req.method == 'POST' && req.body.action.hasOwnProperty('clear'))) {
+    // STEFAN: Check for equality over action.hasOwnProperty
+    || (req.method == 'POST' && req.body.action === 'clear')) {
         filter[args.name] = {
             columns: {},
             order: '',
@@ -16,7 +19,8 @@ exports.prepareSession = function (req, args) {
             or: false
         };
     }
-    else if (req.method == 'POST' && req.body.action.hasOwnProperty('filter')) {
+    // STEFAN: Check for equality over action.hasOwnProperty
+    else if (req.method == 'POST' && req.body.action === 'filter') {
         filter[args.name] = {
             columns: req.body.filter||{},
             order: req.body.order,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "express-admin-better-defaults",
-    "version": "1.7.3",
+    "version": "1.8.0",
     "description": "MySql, MariaDB, SQLite and PostgreSQL database admin built with Express and Bootstrap",
     "keywords": [
         "mysql",

--- a/public/express-admin.css
+++ b/public/express-admin.css
@@ -12,7 +12,7 @@
 }
 .container-fluid { width: auto; max-width: none; }
 
-/*Stefan: get rid of giant left side margin*/
+/*STEFAN: get rid of giant left side margin*/
 /*TODO: more elegant solution*/
 .container { margin-left: 0px !important }
 
@@ -21,7 +21,7 @@
 
 /*fix table size and content*/
 
-/* Stefan: allow horizontal scrolling for large tables */
+/* STEFAN: allow horizontal scrolling for large tables */
 /* .x-table { table-layout: fixed; } */
 
 .x-table thead th,

--- a/routes/filter.js
+++ b/routes/filter.js
@@ -1,0 +1,16 @@
+// STEFAN: changes the content of the request body from
+// { filter[fieldName]: 'filterBy' } 
+// to
+// { filter: { fieldName: 'filterBy } }
+// This is necessary for actual filtering by express-admin
+
+exports.hotfix = function (req, res, next) {
+  Object.keys(req.body).forEach((key) => {
+    if (key.includes('filter[')) {
+      req.body.filter = req.body.filter || {}
+      req.body.filter[key.replace(/filter\[|\]/g, '')] = req.body[key]
+      delete req.body[key]
+    }
+  })
+  next();
+} 

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,3 +8,6 @@ exports.listview = require('./listview');
 exports.editview = require('./editview');
 
 exports.render   = require('./render');
+
+// STEFAN: add filter middle ware to correct filter data on the req body.
+exports.filter = require('./filter');

--- a/views/listview/filter.html
+++ b/views/listview/filter.html
@@ -15,7 +15,7 @@
                     <td>
                         <div class="form-group">
                             {{#row}}
-                                {{>column}}
+                                {{> column}}
                             {{/row}}
                         </div>
                     </td>
@@ -44,8 +44,9 @@
                 {{/direction}}
             </div>
             <div class="col-lg-3 col-md-3 col-sm-3">
-                <button type="submit" class="btn btn-default form-control" name="action[filter]">{{string.filter}}</button>
-                <button type="submit" class="btn btn-default form-control" name="action[clear]">{{string.clear}}</button>
+              <!-- STEFAN: action and value are a key: value pair -->
+                <button type="submit" class="btn btn-default form-control" name="action" value="filter">{{string.filter}}</button>
+                <button type="submit" class="btn btn-default form-control" name="action" value="clear">{{string.clear}}</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
 - Don't show association tables by default.
   - Should users be able to see/edit associated ids?
   - Association tables are still created in `settings.json` but are set to `show: false`.
   - Make visible with `show: true`.

 - Functional filtering.
   - Create new middleware `filter.js` to correct the 'filter objects passed on the `req`.